### PR TITLE
Alert issue on 'reset' fixed

### DIFF
--- a/Tug-of-Word/ViewModels/GameViewModel.swift
+++ b/Tug-of-Word/ViewModels/GameViewModel.swift
@@ -71,7 +71,7 @@ class GameViewModel: ObservableObject {
             timeRemaining -= 1
         } else if sandboxMode == true {
             timerStopped = true
-        } else {
+        } else if timeRemaining == 0 {
             showLoseAlert = true
             timerStopped = true
         }


### PR DESCRIPTION
lose alert was showing after restart, because the timer wasn't stopped AND it was still running

changed last if statement to make sure the timer is at 0 when the lose alert is displayed